### PR TITLE
Fix student setup: venv activation, ansible-core, collections

### DIFF
--- a/docs/EXERCISES.md
+++ b/docs/EXERCISES.md
@@ -18,6 +18,14 @@ Complete each phase in sequence. Run `make test` after each phase.
 make setup
 ```
 
+Then activate the Python environment:
+
+```bash
+source venv/bin/activate
+```
+
+Your terminal prompt will show `(venv)` when active. You need to do this once per terminal session.
+
 ---
 
 ## PHASE 1: Intelligence Gathering

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ansible-core
 pytest
 testinfra
 pyyaml

--- a/scripts/setup-lab.sh
+++ b/scripts/setup-lab.sh
@@ -26,6 +26,7 @@ if [ ! -d "$ROOT_DIR/venv" ]; then
     echo "  Setting up Python environment..."
     python3 -m venv "$ROOT_DIR/venv"
     "$ROOT_DIR/venv/bin/pip" install -q -r "$ROOT_DIR/requirements.txt"
+    "$ROOT_DIR/venv/bin/ansible-galaxy" collection install community.general ansible.posix -q
     echo "  Python environment ready."
     echo ""
 fi


### PR DESCRIPTION
## Summary
- Add `ansible-core` to `requirements.txt` so Ansible is available in the venv
- Add venv activation step (`source venv/bin/activate`) to Phase 0 in EXERCISES.md
- Add `ansible-galaxy collection install` to `setup-lab.sh` (where applicable)

## Test plan
- [ ] `make setup` completes without error
- [ ] `source venv/bin/activate && ansible --version` works
- [ ] Ansible commands work from workspace/ after activation

Fixes starfall-defence-corps/sdc-academy#16