### PR TITLE
Fix vault_password_file blocking ansible before .vault-pass exists

### DIFF
--- a/docs/EXERCISES.md
+++ b/docs/EXERCISES.md
@@ -214,7 +214,15 @@ echo 'starfall-academy-2187' > .vault-pass
 chmod 600 .vault-pass
 ```
 
-This file is **gitignored** — it never enters version control. The `ansible.cfg` already references it via `vault_password_file = .vault-pass`.
+This file is **gitignored** — it never enters version control.
+
+Now enable vault integration in `ansible.cfg`. Open `workspace/ansible.cfg` and uncomment the vault line:
+
+```ini
+vault_password_file = .vault-pass
+```
+
+This tells Ansible to automatically use `.vault-pass` for decrypting vault files.
 
 ### Step 3.2 — Create the Vault File
 

--- a/docs/HINTS.md
+++ b/docs/HINTS.md
@@ -78,7 +78,7 @@ ansible-vault view vault.yml
 
 **The vault password file:**
 
-`ansible.cfg` has `vault_password_file = .vault-pass`. Create this file with your vault password:
+`ansible.cfg` has a commented-out `vault_password_file = .vault-pass` line. Create the password file first, then uncomment the line:
 
 ```bash
 echo 'your-password-here' > .vault-pass

--- a/workspace/ansible.cfg
+++ b/workspace/ansible.cfg
@@ -6,7 +6,8 @@ private_key_file = .ssh/cadet_key
 deprecation_warnings = False
 interpreter_python = auto_silent
 roles_path = roles
-vault_password_file = .vault-pass
+# Uncomment after creating .vault-pass in Phase 3:
+# vault_password_file = .vault-pass
 
 [privilege_escalation]
 become = True


### PR DESCRIPTION
## Summary
- Comment out `vault_password_file` in shipped `ansible.cfg` so students can run ansible commands in Phases 1-2
- Add explicit "uncomment this line" step to Phase 3 exercises after students create `.vault-pass`
- Update HINTS.md to reflect the commented-out default

## Problem
`ansible.cfg` referenced `.vault-pass` which doesn't exist until Phase 3. Any ansible command (even `ansible all -m ping`) failed at startup with a vault password file error.

## Test plan
- [ ] `ansible all -m ping` works before creating `.vault-pass`
- [ ] After creating `.vault-pass` and uncommenting, `ansible-vault` commands work
- [ ] Full mission flow completes

Fixes starfall-defence-corps/sdc-academy#16