### PR TITLE
Fix ansible-galaxy -q flag in setup-lab.sh

### DIFF
--- a/scripts/setup-lab.sh
+++ b/scripts/setup-lab.sh
@@ -26,7 +26,7 @@ if [ ! -d "$ROOT_DIR/venv" ]; then
     echo "  Setting up Python environment..."
     python3 -m venv "$ROOT_DIR/venv"
     "$ROOT_DIR/venv/bin/pip" install -q -r "$ROOT_DIR/requirements.txt"
-    "$ROOT_DIR/venv/bin/ansible-galaxy" collection install community.general ansible.posix -q
+    "$ROOT_DIR/venv/bin/ansible-galaxy" collection install community.general ansible.posix > /dev/null
     echo "  Python environment ready."
     echo ""
 fi


### PR DESCRIPTION
## Summary
Fix `ansible-galaxy collection install ... -q` — the `-q` flag is not supported and kills `make setup`.

## Fix
Replace `-q` with `> /dev/null`.

Fixes starfall-defence-corps/sdc-academy#17